### PR TITLE
Fix schema issue for property with integer/string values and other minor updates

### DIFF
--- a/src/main/scala/com/microsoft/azure/documentdb/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/azure/documentdb/spark/Constants.scala
@@ -1,0 +1,28 @@
+/**
+  * The MIT License (MIT)
+  * Copyright (c) 2016 Microsoft Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
+package com.microsoft.azure.documentdb.spark
+
+object Constants {
+  val currentVersion = "0.0.2-SNAPSHOT"
+  val userAgentSuffix = s" SparkConnector/$currentVersion"
+}

--- a/src/main/scala/com/microsoft/azure/documentdb/spark/DocumentDBConnection.scala
+++ b/src/main/scala/com/microsoft/azure/documentdb/spark/DocumentDBConnection.scala
@@ -48,21 +48,22 @@ private[spark] case class DocumentDBConnection(config: Config) extends LoggingTr
   }
 
   private def accquireClient(): DocumentClient = {
-    val cp = ConnectionPolicy.GetDefault()
-    cp.setConnectionMode(ConnectionMode.DirectHttps)
+    val connectionPolicy = ConnectionPolicy.GetDefault()
+    connectionPolicy.setConnectionMode(ConnectionMode.DirectHttps)
+    connectionPolicy.setUserAgentSuffix(Constants.userAgentSuffix)
 
     val option = config.get[String](DocumentDBConfig.PreferredRegionsList)
 
     if (option.isDefined) {
       logWarning(s"DocumentDBConnection::Input preferred region list: ${option.get}")
       val preferredLocations = option.get.split(";").toSeq.map(_.trim)
-      cp.setPreferredLocations(preferredLocations)
+      connectionPolicy.setPreferredLocations(preferredLocations)
     }
 
     client = new DocumentClient(
       config.get("EndPoint").getOrElse("endpoint"),
       config.get("Masterkey").getOrElse("masterkey"),
-      cp,
+      connectionPolicy,
       ConsistencyLevel.Session)
     client
   }

--- a/src/main/scala/com/microsoft/azure/documentdb/spark/partitioner/DocumentDBPartition.scala
+++ b/src/main/scala/com/microsoft/azure/documentdb/spark/partitioner/DocumentDBPartition.scala
@@ -26,4 +26,4 @@ import org.apache.spark.Partition
 
 case class DocumentDBPartition(
                                 index: Int,
-                                hosts: Seq[String]) extends Partition
+                                partitionCount: Int) extends Partition

--- a/src/main/scala/com/microsoft/azure/documentdb/spark/partitioner/DocumentDBPartitioner.scala
+++ b/src/main/scala/com/microsoft/azure/documentdb/spark/partitioner/DocumentDBPartitioner.scala
@@ -32,17 +32,8 @@ class DocumentDBPartitioner() extends Partitioner[DocumentDBPartition] with Logg
     */
   override def computePartitions(config: Config): Array[DocumentDBPartition] = {
     var connection: DocumentDBConnection = new DocumentDBConnection(config)
-
-    var partitions = connection.getAllPartitions.map(p => DocumentDBPartition(p.getId().toInt, List("")))
-    logDebug(s"DocumentDBPartitioner: This DocumentDB has ${partitions.size} partitions")
-
-    partitions
+    var partitionKeyRanges = connection.getAllPartitions
+    logDebug(s"DocumentDBPartitioner: This DocumentDB has ${partitionKeyRanges.size} partitions")
+    partitionKeyRanges.map(p => DocumentDBPartition(p.getId().toInt, partitionKeyRanges.length))
   }
-
-}
-
-object DocumentDBPartitioner {
-  val ConfigDatabase = "config"
-  val ChunksCollection = "chunks"
-  val ShardsCollection = "shards"
 }

--- a/src/main/scala/com/microsoft/azure/documentdb/spark/rdd/DocumentDBRDD.scala
+++ b/src/main/scala/com/microsoft/azure/documentdb/spark/rdd/DocumentDBRDD.scala
@@ -38,7 +38,7 @@ import scala.reflect.runtime.universe._
 class DocumentDBRDD(
                      spark: SparkSession,
                      config: Config,
-                     maxItems: Option[Long] = null,
+                     maxItems: Option[Long] = None,
                      partitioner: DocumentDBPartitioner = new DocumentDBPartitioner(),
                      requiredColumns: Array[String] = Array(),
                      filters: Array[Filter] = Array())
@@ -52,9 +52,6 @@ class DocumentDBRDD(
 
   override def getPartitions: Array[Partition] =
     partitioner.computePartitions(config).asInstanceOf[Array[Partition]]
-
-  override def getPreferredLocations(split: Partition): Seq[String] =
-    split.asInstanceOf[DocumentDBPartition].hosts.map(new String(_))
 
   /**
     * Creates a `DataFrame` based on the schema derived from the optional type.
@@ -117,7 +114,7 @@ class DocumentDBRDD(
       context,
       documentDBPartition,
       config,
-      maxItems,
+      maxItems.map{ x => x / documentDBPartition.partitionCount },
       requiredColumns,
       filters)
   }

--- a/src/main/scala/com/microsoft/azure/documentdb/spark/rdd/DocumentDBRDDIterator.scala
+++ b/src/main/scala/com/microsoft/azure/documentdb/spark/rdd/DocumentDBRDDIterator.scala
@@ -63,7 +63,7 @@ class DocumentDBRDDIterator(
   taskContext.addTaskCompletionListener((context: TaskContext) => closeIfNeeded())
 
   override def hasNext: Boolean = {
-    if (maxItems != null && maxItems.isDefined && maxItems.get < itemCount) {
+    if (maxItems != null && maxItems.isDefined && maxItems.get <= itemCount) {
       return false
     }
     !closed && reader.hasNext

--- a/src/main/scala/com/microsoft/azure/documentdb/spark/schema/JsonSupport.scala
+++ b/src/main/scala/com/microsoft/azure/documentdb/spark/schema/JsonSupport.scala
@@ -23,6 +23,7 @@
 package com.microsoft.azure.documentdb.spark.schema
 
 import java.sql.{Date, Timestamp}
+import java.util.Optional
 
 import org.apache.spark.sql.types._
 
@@ -51,7 +52,7 @@ trait JsonSupport {
         case ByteType => toByte(value)
         case BinaryType => toBinary(value)
         case ShortType => toShort(value)
-        case IntegerType => toInt(value)
+        case IntegerType => toInt(value).getOrElse(null)
         case LongType => toLong(value)
         case DoubleType => toDouble(value)
         case DecimalType() => toDecimal(value)
@@ -86,11 +87,15 @@ trait JsonSupport {
     }
   }
 
-  private def toInt(value: Any): Int = {
+  private def toInt(value: Any): Option[Int] = {
     import scala.language.reflectiveCalls
-    value match {
-      case value: String => value.toInt
-      case _ => value.asInstanceOf[ {def toInt: Int}].toInt
+    try {
+      value match {
+        case value: String => Some(value.toInt)
+        case _ => Some(value.asInstanceOf[ {def toInt: Int}].toInt)
+      }
+    } catch {
+      case e: Exception => None
     }
   }
 

--- a/src/test/scala/com/microsoft/azure/documentdb/spark/DocumentDBDefaults.scala
+++ b/src/test/scala/com/microsoft/azure/documentdb/spark/DocumentDBDefaults.scala
@@ -43,12 +43,13 @@ class DocumentDBDefaults extends LoggingTrait {
 
   var collectionName: String = _
 
-  private val cp = ConnectionPolicy.GetDefault()
-  cp.setConnectionMode(ConnectionMode.DirectHttps)
+  private val connectionPolicy = ConnectionPolicy.GetDefault()
+  connectionPolicy.setConnectionMode(ConnectionMode.DirectHttps)
+  connectionPolicy.setUserAgentSuffix(Constants.userAgentSuffix)
 
   lazy val documentDBClient = {
     var client = new DocumentClient(EMULATOR_ENDPOINT, EMULATOR_MASTERKEY,
-      cp,
+      connectionPolicy,
       ConsistencyLevel.Session)
     client
   }

--- a/src/test/scala/com/microsoft/azure/documentdb/spark/DocumentDBDefaults.scala
+++ b/src/test/scala/com/microsoft/azure/documentdb/spark/DocumentDBDefaults.scala
@@ -38,7 +38,7 @@ class DocumentDBDefaults extends LoggingTrait {
 
   // local emulator
   val EMULATOR_ENDPOINT: String = "https://localhost:443/"
-  val EMULATOR_MASTERKEY: String = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+  val EMULATOR_MASTERKEY: String = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
   val DATABASE_NAME = "documentdb-spark-connector-test"
 
   var collectionName: String = _


### PR DESCRIPTION
- Fixed schema issue for property with integer/string values, partially fix #6. Value that doesn't conform to derived schema will be represented as null.
- Updated sampling size to derive schema.
- Updated user agent string.

cc; @dennyglee @shireeshkthota @mingaliu