### PR TITLE
Improve partitions mapping so document query is sent to target partitions only

### DIFF
--- a/src/main/scala/com/microsoft/azure/documentdb/BridgeInternal.scala
+++ b/src/main/scala/com/microsoft/azure/documentdb/BridgeInternal.scala
@@ -22,6 +22,9 @@
   */
 package com.microsoft.azure.documentdb
 
+import com.microsoft.azure.documentdb.internal.routing.RoutingMapProvider
+import com.microsoft.azure.documentdb.internal.{DocumentServiceRequest, DocumentServiceResponse}
+
 
 /**
   * This is meant to be used only internally as a bridge access to
@@ -31,5 +34,13 @@ object BridgeInternal {
 
   def SetFeedOptionPartitionKeyRangeId(options: FeedOptions, partitionKeyRangeId: String): Unit = {
     options.setPartitionKeyRangeIdInternal(partitionKeyRangeId)
+  }
+
+  def getDocumentClientDoQuery(client: DocumentClient): DocumentServiceRequest => DocumentServiceResponse = {
+    client.doQuery
+  }
+
+  def getDocumentClientPartitionKeyRangeCache(client: DocumentClient): RoutingMapProvider = {
+    client.getPartitionKeyRangeCache
   }
 }

--- a/src/main/scala/com/microsoft/azure/documentdb/spark/DocumentDBConnection.scala
+++ b/src/main/scala/com/microsoft/azure/documentdb/spark/DocumentDBConnection.scala
@@ -22,10 +22,15 @@
   */
 package com.microsoft.azure.documentdb.spark
 
+import java.util.HashMap
+
 import com.microsoft.azure.documentdb._
-import com.microsoft.azure.documentdb.internal.Paths
+import com.microsoft.azure.documentdb.internal._
+import com.microsoft.azure.documentdb.internal.query.PartitionedQueryExecutionInfo
+import com.microsoft.azure.documentdb.internal.routing.RoutingMapProviderHelper
 import com.microsoft.azure.documentdb.spark.config._
 
+import scala.collection.{JavaConversions, mutable}
 import scala.collection.JavaConversions._
 import scala.language.implicitConversions
 
@@ -41,15 +46,14 @@ private[spark] case class DocumentDBConnection(config: Config) extends LoggingTr
   @transient private var client: DocumentClient = _
 
   private def documentClient(): DocumentClient = {
-    client match {
-      case null => accquireClient()
-      case _ => client
-    }
+    if (client == null)
+      client = accquireClient(ConnectionMode.DirectHttps)
+    client
   }
 
-  private def accquireClient(): DocumentClient = {
-    val connectionPolicy = ConnectionPolicy.GetDefault()
-    connectionPolicy.setConnectionMode(ConnectionMode.DirectHttps)
+  private def accquireClient(connectionMode: ConnectionMode): DocumentClient = {
+    val connectionPolicy = new ConnectionPolicy()
+    connectionPolicy.setConnectionMode(connectionMode)
     connectionPolicy.setUserAgentSuffix(Constants.userAgentSuffix)
 
     val option = config.get[String](DocumentDBConfig.PreferredRegionsList)
@@ -60,17 +64,69 @@ private[spark] case class DocumentDBConnection(config: Config) extends LoggingTr
       connectionPolicy.setPreferredLocations(preferredLocations)
     }
 
-    client = new DocumentClient(
+    var documentClient = new DocumentClient(
       config.get("EndPoint").getOrElse("endpoint"),
       config.get("Masterkey").getOrElse("masterkey"),
       connectionPolicy,
       ConsistencyLevel.Session)
-    client
+    documentClient
   }
 
   def getAllPartitions: Array [PartitionKeyRange] = {
     var ranges = documentClient().readPartitionKeyRanges(collectionLink, null)
     ranges.getQueryIterator.toArray
+  }
+
+  def getAllPartitions(query: String): Array[PartitionKeyRange] = {
+    val querySpec = new SqlQuerySpec(query, new SqlParameterCollection)
+    val options = new FeedOptions
+    options.setEnableCrossPartitionQuery(true)
+    options.setMaxDegreeOfParallelism(Integer.MAX_VALUE)
+
+    var headers: HashMap[String, String] = new HashMap[String, String]
+    headers.put(HttpConstants.HttpHeaders.ENABLE_CROSS_PARTITION_QUERY, String.valueOf(true))
+    headers.put(HttpConstants.HttpHeaders.PARALLELIZE_CROSS_PARTITION_QUERY, String.valueOf(true))
+    headers.put(HttpConstants.HttpHeaders.PAGE_SIZE, String.valueOf(1))
+    var path: String = null
+    var partitionKeyRanges: Array[PartitionKeyRange] = Array()
+    if (Utils.isDatabaseLink(collectionLink))
+      path = collectionLink
+    else
+      path = Utils.joinPath(collectionLink, Paths.DOCUMENTS_PATH_SEGMENT)
+    var gwClient = accquireClient(ConnectionMode.Gateway)
+    try {
+      val request = DocumentServiceRequest.create(
+        ResourceType.Document,
+        path,
+        querySpec,
+        QueryCompatibilityMode.Default,
+        JavaConversions.mapAsJavaMap(headers))
+      val response = BridgeInternal.getDocumentClientDoQuery(gwClient)(request)
+
+      val sessionToken = response.getResponseHeaders.get(HttpConstants.HttpHeaders.SESSION_TOKEN)
+      if (!sessionToken.isEmpty) {
+        val parts = sessionToken.split(":")
+        if (parts.size == 2) {
+          val singleRange = new PartitionKeyRange()
+          singleRange.setId(parts(0))
+          partitionKeyRanges = Array(singleRange)
+        }
+      }
+
+      if (partitionKeyRanges.length == 0) {
+        // Partition key ranges information not returned from Gateway
+        partitionKeyRanges = getAllPartitions
+      }
+    } catch {
+      case dce: DocumentClientException =>
+        val partitionedQueryExecutionInfo = new PartitionedQueryExecutionInfo(dce.getError.getPartitionedQueryExecutionInfo)
+        partitionKeyRanges = RoutingMapProviderHelper.getOverlappingRanges(
+          BridgeInternal.getDocumentClientPartitionKeyRangeCache(documentClient()),
+          path,
+          partitionedQueryExecutionInfo.getQueryRanges).toArray[PartitionKeyRange](partitionKeyRanges)
+    }
+
+    partitionKeyRanges
   }
 
   def queryDocuments (queryString : String,

--- a/src/main/scala/com/microsoft/azure/documentdb/spark/DocumentDBSpark.scala
+++ b/src/main/scala/com/microsoft/azure/documentdb/spark/DocumentDBSpark.scala
@@ -43,8 +43,6 @@ import scala.reflect.runtime.universe._
   */
 object DocumentDBSpark {
 
-  private val DefaultMaxBatchSize = 512
-
   /**
    * The default source string for creating DataFrames from DocumentDB
    */

--- a/src/main/scala/com/microsoft/azure/documentdb/spark/partitioner/DocumentDBPartition.scala
+++ b/src/main/scala/com/microsoft/azure/documentdb/spark/partitioner/DocumentDBPartition.scala
@@ -24,6 +24,6 @@ package com.microsoft.azure.documentdb.spark.partitioner
 
 import org.apache.spark.Partition
 
-case class DocumentDBPartition(
-                                index: Int,
-                                partitionCount: Int) extends Partition
+case class DocumentDBPartition(index: Int,
+                              partitionCount: Int,
+                              documentDBIndex: Int) extends Partition

--- a/src/main/scala/com/microsoft/azure/documentdb/spark/rdd/DocumentDBRDD.scala
+++ b/src/main/scala/com/microsoft/azure/documentdb/spark/rdd/DocumentDBRDD.scala
@@ -51,7 +51,7 @@ class DocumentDBRDD(
   override def toJavaRDD(): JavaDocumentDBRDD = JavaDocumentDBRDD(this)
 
   override def getPartitions: Array[Partition] =
-    partitioner.computePartitions(config).asInstanceOf[Array[Partition]]
+    partitioner.computePartitions(config, requiredColumns, filters).asInstanceOf[Array[Partition]]
 
   /**
     * Creates a `DataFrame` based on the schema derived from the optional type.
@@ -104,10 +104,10 @@ class DocumentDBRDD(
                         context: TaskContext): DocumentDBRDDIterator = {
 
     var documentDBPartition: DocumentDBPartition = split.asInstanceOf[DocumentDBPartition]
-    logDebug(s"DocumentDBRDD:compute: Start DocumentDBRDD compute on partition with index ${split.index}")
+    logDebug(s"DocumentDBRDD:compute: Start DocumentDBRDD compute on partition with index ${documentDBPartition.documentDBIndex}")
 
     context.addTaskCompletionListener((ctx: TaskContext) => {
-      logDebug("DocumentDBRDD:compute: Task completed RDD compute ${split.index}")
+      logDebug(s"DocumentDBRDD:compute: Task completed RDD compute ${documentDBPartition.documentDBIndex}")
     })
 
     new DocumentDBRDDIterator(

--- a/src/test/scala/com/microsoft/azure/documentdb/spark/schema/DocumentDBDataFrameSpec.scala
+++ b/src/test/scala/com/microsoft/azure/documentdb/spark/schema/DocumentDBDataFrameSpec.scala
@@ -127,6 +127,19 @@ class DocumentDBDataFrameSpec extends RequiresDocumentDB {
     df.rdd.map(x => x.get(0)).collect() should contain theSameElementsAs expectedValues
   }
 
+  it should "send query to target partitions only" in withSparkContext() { sc =>
+    sc.parallelize((1 to documentCount).map(x => new Document(s"{pkey: $x}"))).saveToDocumentDB()
+
+    val sparkSession = createOrGetDefaultSparkSession(sc)
+
+    val coll = sparkSession.sqlContext.read.DocumentDB()
+    coll.createOrReplaceTempView("c")
+
+    sparkSession.sql("SELECT * FROM c WHERE c.pkey = 1").rdd.getNumPartitions should equal(1)
+    sparkSession.sql("SELECT * FROM c WHERE c.pkey IN (1, 2)").rdd.getNumPartitions should equal(2)
+    sparkSession.sql("SELECT * FROM c").rdd.getNumPartitions should equal(coll.rdd.getNumPartitions)
+  }
+
   it should "should be easily created from the SQLContext and load from DocumentDB" in withSparkContext() { sc =>
     val sparkSession = createOrGetDefaultSparkSession(sc)
     import sparkSession.implicits._


### PR DESCRIPTION
This will help avoid unnecessary query round trips to inapplicable partitions (Fix #5)

cc: @dennyglee @shireeshkthota